### PR TITLE
Add subnet parent test

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 1.6.0
+current_version = 1.6.1
 
 [bumpversion:file:galaxy.yml]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,6 +22,7 @@ A clear and concise description of what you expected to happen.
 - Ansible:
 - phpipam-ansible-modules:
 - phpypam:
+- phpIPAM:
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,17 @@ jobs:
   test:
     name: end to end tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        phpipam-version: ['1.4x', '1.5x']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: setup phpipam
-        uses: codeaffen/phpipam-action@v1
+        uses: codeaffen/phpipam-action@v2
+        with:
+          ipam_version: ${{ matrix.phpipam-version }}
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.x'
       - name: setup test environment

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,22 @@ codeaffen.phpipam Release Notes
 .. contents:: Topics
 
 
+v1.6.1
+======
+
+Bugfixes
+--------
+
+- fix \#90 - booleans in subnet module aren't working
+- fix \#93 - trouble creating subnet with a vrf
+
+Enhancements
+------------
+
+- Enhance test suite by running test agains main phpipam versions as matrix build
+- Update test playbooks to meet best practices for ansible 2.10.x
+- move to nodejs 16 for `checkout` and `setup-python` action
+
 v1.6.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -139,3 +139,18 @@ releases:
     - l2domain_parameter_in_subnet module.yml
     - same_vlan_in_different_l2domains.yml
     release_date: '2022-09-02'
+  1.6.1:
+    changes:
+      bugfixes:
+      - fix \#90 - booleans in subnet module aren't working
+      - fix \#93 - trouble creating subnet with a vrf
+      enhancements:
+      - Enhance test suite by running test agains main phpipam versions as matrix
+        build
+      - Update test playbooks to meet best practices for ansible 2.10.x
+      - move to nodejs 16 for `checkout` and `setup-python` action
+    fragments:
+    - ' booleans_in_subnet_module_not_working.yml'
+    - level_up_tests.yml
+    - trouble_creating_subnet_with_a_vrf.yml
+    release_date: '2023-01-24'

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -27,6 +27,8 @@ sections:
   - Bugfixes
 - - known_issues
   - Known Issues
+- - enhancements
+  - Enhancements
 title: codeaffen.phpipam
 trivial_section_name: trivial
 use_fqcn: true

--- a/changelogs/fragments/ booleans_in_subnet_module_not_working.yml
+++ b/changelogs/fragments/ booleans_in_subnet_module_not_working.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - fix \#90 - booleans in subnet module aren't working

--- a/changelogs/fragments/level_up_tests.yml
+++ b/changelogs/fragments/level_up_tests.yml
@@ -1,0 +1,8 @@
+bugfixes:
+  - Enhance test suite by running test agains main phpipam versions as matrix build
+  - Update test playbooks to meet best practices for ansible 2.10.x
+    - use FQCNs
+    - migrate from `include` to `include_tasks`
+    - Add missing names
+    - Start names with upper case letters
+  - move to nodejs 16 for `checkout` and `setup-python` action

--- a/changelogs/fragments/level_up_tests.yml
+++ b/changelogs/fragments/level_up_tests.yml
@@ -1,8 +1,0 @@
-bugfixes:
-  - Enhance test suite by running test agains main phpipam versions as matrix build
-  - Update test playbooks to meet best practices for ansible 2.10.x
-    - use FQCNs
-    - migrate from `include` to `include_tasks`
-    - Add missing names
-    - Start names with upper case letters
-  - move to nodejs 16 for `checkout` and `setup-python` action

--- a/changelogs/fragments/trouble_creating_subnet_with_a_vrf.yml
+++ b/changelogs/fragments/trouble_creating_subnet_with_a_vrf.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - fix \#93 - trouble creating subnet with a vrf

--- a/docs/plugins/address_module.rst
+++ b/docs/plugins/address_module.rst
@@ -42,7 +42,7 @@ codeaffen.phpipam.address module -- Manage addresses
 .. Collection note
 
 .. note::
-    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.0).
+    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.1).
 
     You might already have this collection installed if you are using the ``ansible`` package.
     It is not included in ``ansible-core``.

--- a/docs/plugins/device_module.rst
+++ b/docs/plugins/device_module.rst
@@ -42,7 +42,7 @@ codeaffen.phpipam.device module -- Manage devices
 .. Collection note
 
 .. note::
-    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.0).
+    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.1).
 
     You might already have this collection installed if you are using the ``ansible`` package.
     It is not included in ``ansible-core``.

--- a/docs/plugins/device_type_module.rst
+++ b/docs/plugins/device_type_module.rst
@@ -42,7 +42,7 @@ codeaffen.phpipam.device_type module -- Manage device types
 .. Collection note
 
 .. note::
-    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.0).
+    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.1).
 
     You might already have this collection installed if you are using the ``ansible`` package.
     It is not included in ``ansible-core``.

--- a/docs/plugins/domain_module.rst
+++ b/docs/plugins/domain_module.rst
@@ -42,7 +42,7 @@ codeaffen.phpipam.domain module -- Manage L2 routing domains
 .. Collection note
 
 .. note::
-    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.0).
+    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.1).
 
     You might already have this collection installed if you are using the ``ansible`` package.
     It is not included in ``ansible-core``.

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -5,7 +5,7 @@
 Codeaffen.Phpipam
 =================
 
-Collection version 1.6.0
+Collection version 1.6.1
 
 .. contents::
    :local:

--- a/docs/plugins/location_module.rst
+++ b/docs/plugins/location_module.rst
@@ -42,7 +42,7 @@ codeaffen.phpipam.location module -- Manage locations
 .. Collection note
 
 .. note::
-    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.0).
+    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.1).
 
     You might already have this collection installed if you are using the ``ansible`` package.
     It is not included in ``ansible-core``.

--- a/docs/plugins/nameserver_module.rst
+++ b/docs/plugins/nameserver_module.rst
@@ -42,7 +42,7 @@ codeaffen.phpipam.nameserver module -- Manage nameservers
 .. Collection note
 
 .. note::
-    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.0).
+    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.1).
 
     You might already have this collection installed if you are using the ``ansible`` package.
     It is not included in ``ansible-core``.

--- a/docs/plugins/section_module.rst
+++ b/docs/plugins/section_module.rst
@@ -42,7 +42,7 @@ codeaffen.phpipam.section module -- Manage sections
 .. Collection note
 
 .. note::
-    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.0).
+    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.1).
 
     You might already have this collection installed if you are using the ``ansible`` package.
     It is not included in ``ansible-core``.

--- a/docs/plugins/subnet_module.rst
+++ b/docs/plugins/subnet_module.rst
@@ -42,7 +42,7 @@ codeaffen.phpipam.subnet module -- Manage subnets
 .. Collection note
 
 .. note::
-    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.0).
+    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.1).
 
     You might already have this collection installed if you are using the ``ansible`` package.
     It is not included in ``ansible-core``.

--- a/docs/plugins/tag_module.rst
+++ b/docs/plugins/tag_module.rst
@@ -42,7 +42,7 @@ codeaffen.phpipam.tag module -- Manage tags
 .. Collection note
 
 .. note::
-    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.0).
+    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.1).
 
     You might already have this collection installed if you are using the ``ansible`` package.
     It is not included in ``ansible-core``.

--- a/docs/plugins/vlan_module.rst
+++ b/docs/plugins/vlan_module.rst
@@ -42,7 +42,7 @@ codeaffen.phpipam.vlan module -- Manage vlans
 .. Collection note
 
 .. note::
-    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.0).
+    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.1).
 
     You might already have this collection installed if you are using the ``ansible`` package.
     It is not included in ``ansible-core``.

--- a/docs/plugins/vrf_module.rst
+++ b/docs/plugins/vrf_module.rst
@@ -42,7 +42,7 @@ codeaffen.phpipam.vrf module -- Manage virtual routers and forwarders
 .. Collection note
 
 .. note::
-    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.0).
+    This module is part of the `codeaffen.phpipam collection <https://galaxy.ansible.com/codeaffen/phpipam>`_ (version 1.6.1).
 
     You might already have this collection installed if you are using the ``ansible`` package.
     It is not included in ``ansible-core``.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ authors:
   - "Mario Fritschen <github@fritschen.net>"
   - "Scott Arthur <scott@scottatron.com>"
   - "lush <porous@web.de>"
-version: "1.6.0"
+version: "1.6.1"
 license:
   - "GPL-3.0-or-later"
 tags:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ coverage
 geopy
 wheel
 jinja2 # pyup: ignore
-PyYAML~=5.3
+PyYAML~=6.0
 cryptography
 packaging
 requests

--- a/tests/test_playbooks/address.yml
+++ b/tests/test_playbooks/address.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Address module tests
+  hosts: localhost
   collections:
     - codeaffen.phpipam
   gather_facts: false
@@ -7,28 +8,28 @@
     - vars/server.yml
     - vars/address.yml
   tasks:
-    - name: create address
-      include: tasks/address.yml
+    - name: Create address
+      ansible.builtin.include_tasks: tasks/address.yml
       vars:
         name: create address
         address: "{{ base_address_data }}"
 
-    - name: create address again, no change
-      include: tasks/address.yml
+    - name: Create address again, no change
+      ansible.builtin.include_tasks: tasks/address.yml
       vars:
         name: create address again, no change
         address: "{{ base_address_data }}"
 
-    - name: update address
-      include: tasks/address.yml
+    - name: Update address
+      ansible.builtin.include_tasks: tasks/address.yml
       vars:
         name: update address
         override:
           description: address updated
         address: "{{ base_address_data | combine(override) }}"
 
-    - name: delete address
-      include: tasks/address.yml
+    - name: Delete address
+      ansible.builtin.include_tasks: tasks/address.yml
       vars:
         name: delete address
         override:

--- a/tests/test_playbooks/device.yml
+++ b/tests/test_playbooks/device.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Device module tests
+  hosts: localhost
   collections:
     - codeaffen.phpipam
   gather_facts: false
@@ -7,20 +8,20 @@
     - vars/server.yml
     - vars/device.yml
   tasks:
-    - name: create device
-      include: tasks/device.yml
+    - name: Create device
+      ansible.builtin.include_tasks: tasks/device.yml
       vars:
         name: create device
         device: "{{ base_device_data }}"
 
-    - name: create device again, no change
-      include: tasks/device.yml
+    - name: Create device again, no change
+      ansible.builtin.include_tasks: tasks/device.yml
       vars:
         name: create device again, no change
         device: "{{ base_device_data }}"
 
-    - name: update device
-      include: tasks/device.yml
+    - name: Update device
+      ansible.builtin.include_tasks: tasks/device.yml
       vars:
         name: update device
         override:
@@ -28,8 +29,8 @@
           snmp_community: 'my secret community'
         device: "{{ base_device_data | combine(override) }}"
 
-    - name: delete device
-      include: tasks/device.yml
+    - name: Delete device
+      ansible.builtin.include_tasks: tasks/device.yml
       vars:
         name: delete device
         override:

--- a/tests/test_playbooks/device_type.yml
+++ b/tests/test_playbooks/device_type.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Device type module tests
+  hosts: localhost
   collections:
     - codeaffen.phpipam
   gather_facts: false
@@ -7,28 +8,28 @@
     - vars/server.yml
     - vars/device_type.yml
   tasks:
-    - name: create device_type
-      include: tasks/device_type.yml
+    - name: Create device_type
+      ansible.builtin.include_tasks: tasks/device_type.yml
       vars:
         name: create device_type
         device_type: "{{ base_device_type_data }}"
 
-    - name: create device_type again, no change
-      include: tasks/device_type.yml
+    - name: Create device_type again, no change
+      ansible.builtin.include_tasks: tasks/device_type.yml
       vars:
         name: create device_type again, no change
         device_type: "{{ base_device_type_data }}"
 
-    - name: update device_type
-      include: tasks/device_type.yml
+    - name: Update device_type
+      ansible.builtin.include_tasks: tasks/device_type.yml
       vars:
         name: update device_type
         override:
           description: device_type updated
         device_type: "{{ base_device_type_data | combine(override) }}"
 
-    - name: delete device_type
-      include: tasks/device_type.yml
+    - name: Delete device_type
+      ansible.builtin.include_tasks: tasks/device_type.yml
       vars:
         name: delete device_type
         override:

--- a/tests/test_playbooks/domain.yml
+++ b/tests/test_playbooks/domain.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Domain module tests
+  hosts: localhost
   collections:
     - codeaffen.phpipam
   gather_facts: false
@@ -7,28 +8,28 @@
     - vars/server.yml
     - vars/domain.yml
   tasks:
-    - name: create domain
-      include: tasks/domain.yml
+    - name: Create domain
+      ansible.builtin.include_tasks: tasks/domain.yml
       vars:
         name: create domain
         domain: "{{ base_domain_data }}"
 
-    - name: create domain again, no change
-      include: tasks/domain.yml
+    - name: Create domain again, no change
+      ansible.builtin.include_tasks: tasks/domain.yml
       vars:
         name: create domain again, no change
         domain: "{{ base_domain_data }}"
 
-    - name: update domain
-      include: tasks/domain.yml
+    - name: Update domain
+      ansible.builtin.include_tasks: tasks/domain.yml
       vars:
         name: update domain
         override:
           description: domain updated
         domain: "{{ base_domain_data | combine(override) }}"
 
-    - name: delete domain
-      include: tasks/domain.yml
+    - name: Delete domain
+      ansible.builtin.include_tasks: tasks/domain.yml
       vars:
         name: delete domain
         override:

--- a/tests/test_playbooks/domain_vlan_mapping.yml
+++ b/tests/test_playbooks/domain_vlan_mapping.yml
@@ -1,4 +1,5 @@
-- hosts: localhost
+- name: Domain vlan mapping tests
+  hosts: localhost
   collections:
     - codeaffen.phpipam
   gather_facts: false
@@ -7,8 +8,8 @@
     - vars/domain.yml
     - vars/vlan.yml
   tasks:
-    - name: create domains for mapping test
-      include: tasks/domain.yml
+    - name: Create domains for mapping test
+      ansible.builtin.include_tasks: tasks/domain.yml
       vars:
         name: create {{ loop_domain_data['name'] }}
         domain: "{{ loop_domain_data }}"
@@ -16,8 +17,8 @@
       loop_control:
         loop_var: loop_domain_data
 
-    - name: create vlans for mapping test
-      include: tasks/vlan.yml
+    - name: Create vlans for mapping test
+      ansible.builtin.include_tasks: tasks/vlan.yml
       vars:
         name: create vlan {{ loop_vlan_data['name'] }}
         vlan: "{{ loop_vlan_data }}"
@@ -25,10 +26,10 @@
       loop_control:
         loop_var: loop_vlan_data
 
-    - name: delete vlans
-      include: tasks/vlan.yml
+    - name: Delete vlans
+      ansible.builtin.include_tasks: tasks/vlan.yml
       vars:
-        name: delete vlan {{ vlan['name'] }}
+        name: Delete vlan {{ vlan['name'] }}
         override:
           state: absent
         vlan: "{{ loop_vlan_data | combine(override) }}"
@@ -36,8 +37,8 @@
       loop_control:
         loop_var: loop_vlan_data
 
-    - name: delete domains
-      include: tasks/domain.yml
+    - name: Delete domains
+      ansible.builtin.include_tasks: tasks/domain.yml
       vars:
         name: delete {{ loop_domain_data['name'] }}
         override:

--- a/tests/test_playbooks/domain_vlan_subnet_mapping.yml
+++ b/tests/test_playbooks/domain_vlan_subnet_mapping.yml
@@ -1,4 +1,4 @@
-- name: Setup domain, vlan and subnet mapping
+- name: Domain, vlan and subnet mapping
   hosts: localhost
   collections:
     - codeaffen.phpipam
@@ -8,7 +8,7 @@
     - vars/domain_vlan_subnet_mapping.yml
   tasks:
     - name: IPAM create sections
-      include_tasks: tasks/section.yml
+      ansible.builtin.include_tasks: tasks/section.yml
       vars:
         name: "create section '{{ section.name }}'"
       loop: "{{ docker_compose_ipam_sections }}"
@@ -17,7 +17,7 @@
       tags: admin_tasks_phpipam
 
     - name: IPAM create L2 domains
-      include_tasks: tasks/domain.yml
+      ansible.builtin.include_tasks: tasks/domain.yml
       vars:
         name: "create l2 domain '{{ domain.name }}'"
       loop: "{{ docker_compose_ipam_l2_domains }}"
@@ -26,7 +26,7 @@
       tags: admin_tasks_phpipam
 
     - name: Create VLANS
-      include_tasks: tasks/vlan.yml
+      ansible.builtin.include_tasks: tasks/vlan.yml
       vars:
         name: "create vlans '{{ vlan.name }}'"
       loop: "{{ docker_compose_ipam_vlans }}"
@@ -35,7 +35,7 @@
       tags: admin_tasks_phpipam
 
     - name: Create IP subnets
-      include_tasks: tasks/subnet.yml
+      ansible.builtin.include_tasks: tasks/subnet.yml
       vars:
         name: "create subnet '{{ subnet.name }}'"
       loop: "{{ docker_compose_ipam_subnets }}"

--- a/tests/test_playbooks/example_setup.yml
+++ b/tests/test_playbooks/example_setup.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Simple example setup
+  hosts: localhost
   collections:
     - codeaffen.phpipam
   gather_facts: false
@@ -8,29 +9,30 @@
     - vars/section.yml
     - vars/subnet.yml
   tasks:
-    - name: setup data
-      block:
-      - name: create sections
-        include: tasks/section.yml
-        vars:
-          name: "{{ section.name }}"
-        loop: "{{ sections }}"
-        loop_control:
-          loop_var: section
-
-      - name: create subnets
-        include: tasks/subnet.yml
-        vars:
-          name: "{{ subnet.cidr }}"
-        loop: "{{ subnets }}"
-        loop_control:
-          loop_var: subnet
+    - name: Setup data
       when: cleanup is not defined
-
-    - name: cleanup data
       block:
-        - name: remove subnets
-          include: tasks/subnet.yml
+        - name: Create sections
+          ansible.builtin.include_tasks: tasks/section.yml
+          vars:
+            name: "{{ section.name }}"
+          loop: "{{ sections }}"
+          loop_control:
+            loop_var: section
+
+        - name: Create subnets
+          ansible.builtin.include_tasks: tasks/subnet.yml
+          vars:
+            name: "{{ subnet.cidr }}"
+          loop: "{{ subnets }}"
+          loop_control:
+            loop_var: subnet
+
+    - name: Cleanup data
+      when: cleanup is defined
+      block:
+        - name: Remove subnets
+          ansible.builtin.include_tasks: tasks/subnet.yml
           vars:
             name: "{{ subnet_loop.cidr }}"
             override:
@@ -40,8 +42,8 @@
           loop_control:
             loop_var: subnet_loop
 
-        - name: remove sections
-          include: tasks/section.yml
+        - name: Remove sections
+          ansible.builtin.include_tasks: tasks/section.yml
           vars:
             name: "{{ section_loop.name }}"
             override:
@@ -50,4 +52,3 @@
           loop: "{{ sections | reverse | list }}"
           loop_control:
             loop_var: section_loop
-      when: cleanup is defined

--- a/tests/test_playbooks/location.yml
+++ b/tests/test_playbooks/location.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Location module tests
+  hosts: localhost
   collections:
     - codeaffen.phpipam
   gather_facts: false
@@ -7,20 +8,20 @@
     - vars/server.yml
     - vars/location.yml
   tasks:
-    - name: create location
-      include: tasks/location.yml
+    - name: Create location
+      ansible.builtin.include_tasks: tasks/location.yml
       vars:
         name: create location
         location: "{{ base_location_data }}"
 
-    - name: create location again, no change
-      include: tasks/location.yml
+    - name: Create location again, no change
+      ansible.builtin.include_tasks: tasks/location.yml
       vars:
         name: create location again, no change
         location: "{{ base_location_data }}"
 
-    - name: update location
-      include: tasks/location.yml
+    - name: Update location
+      ansible.builtin.include_tasks: tasks/location.yml
       vars:
         name: update location
         override:
@@ -29,8 +30,8 @@
           longitude: "{{ omit }}"
         location: "{{ base_location_data | combine(override) }}"
 
-    - name: delete location
-      include: tasks/location.yml
+    - name: Delete location
+      ansible.builtin.include_tasks: tasks/location.yml
       vars:
         type: delete location
         override:

--- a/tests/test_playbooks/nameserver.yml
+++ b/tests/test_playbooks/nameserver.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Nameserver module tests
+  hosts: localhost
   collections:
     - codeaffen.phpipam
   gather_facts: false
@@ -7,28 +8,28 @@
     - vars/server.yml
     - vars/nameserver.yml
   tasks:
-    - name: create nameserver
-      include: tasks/nameserver.yml
+    - name: Create nameserver
+      ansible.builtin.include_tasks: tasks/nameserver.yml
       vars:
         name: create nameserver
         nameserver: "{{ base_nameserver_data }}"
 
-    - name: create nameserver again, no change
-      include: tasks/nameserver.yml
+    - name: Create nameserver again, no change
+      ansible.builtin.include_tasks: tasks/nameserver.yml
       vars:
         name: create nameserver again, no change
         nameserver: "{{ base_nameserver_data }}"
 
-    - name: update nameserver
-      include: tasks/nameserver.yml
+    - name: Update nameserver
+      ansible.builtin.include_tasks: tasks/nameserver.yml
       vars:
         name: update nameserver
         override:
           description: nameserver updated
         nameserver: "{{ base_nameserver_data | combine(override) }}"
 
-    - name: delete nameserver
-      include: tasks/nameserver.yml
+    - name: Delete nameserver
+      ansible.builtin.include_tasks: tasks/nameserver.yml
       vars:
         name: delete nameserver
         override:

--- a/tests/test_playbooks/section.yml
+++ b/tests/test_playbooks/section.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Section module tests
+  hosts: localhost
   collections:
     - codeaffen.phpipam
   gather_facts: false
@@ -7,28 +8,28 @@
     - vars/server.yml
     - vars/section.yml
   tasks:
-    - name: create section
-      include: tasks/section.yml
+    - name: Create section
+      ansible.builtin.include_tasks: tasks/section.yml
       vars:
         name: create section
         section: "{{ base_section_data }}"
 
-    - name: create section again, no change
-      include: tasks/section.yml
+    - name: Create section again, no change
+      ansible.builtin.include_tasks: tasks/section.yml
       vars:
         name: create section again, no change
         section: "{{ base_section_data }}"
 
-    - name: update section
-      include: tasks/section.yml
+    - name: Update section
+      ansible.builtin.include_tasks: tasks/section.yml
       vars:
         name: update section
         override:
           description: section updated
         section: "{{ base_section_data | combine(override) }}"
 
-    - name: delete section
-      include: tasks/section.yml
+    - name: Delete section
+      ansible.builtin.include_tasks: tasks/section.yml
       vars:
         name: delete section
         override:

--- a/tests/test_playbooks/subnet.yml
+++ b/tests/test_playbooks/subnet.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Subnet module tests
+  hosts: localhost
   collections:
     - codeaffen.phpipam
   gather_facts: false
@@ -7,20 +8,20 @@
     - vars/server.yml
     - vars/subnet.yml
   tasks:
-    - name: create subnet
-      include: tasks/subnet.yml
+    - name: Create subnet
+      ansible.builtin.include_tasks: tasks/subnet.yml
       vars:
         name: create subnet
         subnet: "{{ base_subnet_data }}"
 
-    - name: create subnet again, no change
-      include: tasks/subnet.yml
+    - name: Create subnet again, no change
+      ansible.builtin.include_tasks: tasks/subnet.yml
       vars:
         name: create subnet again, no change
         subnet: "{{ base_subnet_data }}"
 
-    - name: set booleans
-      include: tasks/subnet.yml
+    - name: Set booleans
+      ansible.builtin.include_tasks: tasks/subnet.yml
       vars:
         name: set booleans
         override:
@@ -34,8 +35,8 @@
           is_full: No
         subnet: "{{ base_subnet_data | combine(override) }}"
 
-    - name: delete subnet
-      include: tasks/subnet.yml
+    - name: Delete subnet
+      ansible.builtin.include_tasks: tasks/subnet.yml
       vars:
         name: delete subnet
         override:

--- a/tests/test_playbooks/subnet_parent.yml
+++ b/tests/test_playbooks/subnet_parent.yml
@@ -1,0 +1,36 @@
+---
+- name: Subnet module tests for subnets with parents/children
+  hosts: localhost
+  collections:
+    - codeaffen.phpipam
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+    - vars/subnet.yml
+  tasks:
+    - name: Create parent/children subnets
+      ansible.builtin.include_tasks: tasks/subnet.yml
+      vars:
+        name: "create subnet '{{ subnet.cidr }}'"
+      loop: "{{ subnet_parents }}"
+      loop_control:
+        loop_var: subnet
+
+    - name: Create parent/children subnets again, no change
+      ansible.builtin.include_tasks: tasks/subnet.yml
+      vars:
+        name: "create subnet '{{ subnet.cidr }}' again, no change"
+      loop: "{{ subnet_parents }}"
+      loop_control:
+        loop_var: subnet
+
+    - name: Delete parent/childre subnets
+      ansible.builtin.include_tasks: tasks/subnet.yml
+      vars:
+        name: delete subnet '{{ subent_loop.cidr }}' again, no change
+        override:
+          state: absent
+        subnet: "{{ subnet_loop | combine(override) }}"
+      loop: "{{ subnet_parents }}"
+      loop_control:
+        loop_var: subnet_loop

--- a/tests/test_playbooks/tag.yml
+++ b/tests/test_playbooks/tag.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Tag module tests
+  hosts: localhost
   collections:
     - codeaffen.phpipam
   gather_facts: false
@@ -7,28 +8,28 @@
     - vars/server.yml
     - vars/tag.yml
   tasks:
-    - name: create tag
-      include: tasks/tag.yml
+    - name: Create tag
+      ansible.builtin.include_tasks: tasks/tag.yml
       vars:
         name: create tag
         tag: "{{ base_tag_data }}"
 
-    - name: create tag again, no change
-      include: tasks/tag.yml
+    - name: Create tag again, no change
+      ansible.builtin.include_tasks: tasks/tag.yml
       vars:
         name: create tag again, no change
         tag: "{{ base_tag_data }}"
 
-    - name: update tag
-      include: tasks/tag.yml
+    - name: Update tag
+      ansible.builtin.include_tasks: tasks/tag.yml
       vars:
         name: update tag
         override:
           bg_color: yellow
         tag: "{{ base_tag_data | combine(override) }}"
 
-    - name: delete tag
-      include: tasks/tag.yml
+    - name: Delete tag
+      ansible.builtin.include_tasks: tasks/tag.yml
       vars:
         type: delete tag
         override:

--- a/tests/test_playbooks/tasks/subnet.yml
+++ b/tests/test_playbooks/tasks/subnet.yml
@@ -14,7 +14,7 @@
     vlan: "{{ subnet.vlan | default(omit) }}"
     routing_domain: "{{ subnet.routing_domain | default(omit) }}"
     vrf: "{{ subnet.vrf | default(omit) }}"
-    master_subnet.cidr: "{{ subnet.master_subnet.cidr | default(omit) }}"
+    parent: "{{ subnet.parent | default(omit) }}"
     nameserver: "{{ subnet.nameserver | default(omit) }}"
     show_as_name: "{{ subnet.show_as_name | default(omit) }}"
     permissions: "{{ subnet.permissions | default(omit) }}"

--- a/tests/test_playbooks/vars/subnet.yml
+++ b/tests/test_playbooks/vars/subnet.yml
@@ -11,3 +11,13 @@ subnets:
     section: "DevOps Department"
   - cidr: 192.0.2.0/25
     section: "Infrastructure Department"
+
+subnet_parents:
+  - cidr: 172.16.0.0/20
+    section: "Customers"
+  - cidr: 172.16.0.0/24
+    section: "Customers"
+    parent: 172.16.0.0/20
+  - cidr: 172.16.1.0/24
+    section: "Customers"
+    parent: 172.16.0.0/20

--- a/tests/test_playbooks/vlan.yml
+++ b/tests/test_playbooks/vlan.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Vlan module tests
+  hosts: localhost
   collections:
     - codeaffen.phpipam
   gather_facts: false
@@ -7,28 +8,28 @@
     - vars/server.yml
     - vars/vlan.yml
   tasks:
-    - name: create vlan
-      include: tasks/vlan.yml
+    - name: Create vlan
+      ansible.builtin.include_tasks: tasks/vlan.yml
       vars:
         name: create vlan
         vlan: "{{ base_vlan_data }}"
 
-    - name: create vlan again, no change
-      include: tasks/vlan.yml
+    - name: Create vlan again, no change
+      ansible.builtin.include_tasks: tasks/vlan.yml
       vars:
         name: create vlan again, no change
         vlan: "{{ base_vlan_data }}"
 
-    - name: update vlan
-      include: tasks/vlan.yml
+    - name: Update vlan
+      ansible.builtin.include_tasks: tasks/vlan.yml
       vars:
         name: update vlan
         override:
           description: vlan updated
         vlan: "{{ base_vlan_data | combine(override) }}"
 
-    - name: delete vlan
-      include: tasks/vlan.yml
+    - name: Delete vlan
+      ansible.builtin.include_tasks: tasks/vlan.yml
       vars:
         name: delete vlan
         override:

--- a/tests/test_playbooks/vrf.yml
+++ b/tests/test_playbooks/vrf.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Vrf module tests
+  hosts: localhost
   collections:
     - codeaffen.phpipam
   gather_facts: false
@@ -7,28 +8,28 @@
     - vars/server.yml
     - vars/vrf.yml
   tasks:
-    - name: create vrf
-      include: tasks/vrf.yml
+    - name: Create vrf
+      ansible.builtin.include_tasks: tasks/vrf.yml
       vars:
         name: create vrf
         vrf: "{{ base_vrf_data }}"
 
-    - name: create vrf again, no change
-      include: tasks/vrf.yml
+    - name: Create vrf again, no change
+      ansible.builtin.include_tasks: tasks/vrf.yml
       vars:
         name: create vrf again, no change
         vrf: "{{ base_vrf_data }}"
 
-    - name: update vrf
-      include: tasks/vrf.yml
+    - name: Update vrf
+      ansible.builtin.include_tasks: tasks/vrf.yml
       vars:
         name: update vrf
         override:
           description: vrf updated
         vrf: "{{ base_vrf_data | combine(override) }}"
 
-    - name: delete vrf
-      include: tasks/vrf.yml
+    - name: Delete vrf
+      ansible.builtin.include_tasks: tasks/vrf.yml
       vars:
         name: delete vrf
         override:


### PR DESCRIPTION
As there is some work needed in managing subnets and/or folders and its
parents a test case is needed.
For that purpose we added a test playbook and a needed variable for
example data.
We also fix a bug in the `subnet` task to.
With all these changes/additions we can test subenets and parent subnets
first. In later steps we need to extend the test to also check the
majority of all combinations of subnets, folders and parents.